### PR TITLE
Esacpe ideographic space

### DIFF
--- a/src/diskover/Diskover.php
+++ b/src/diskover/Diskover.php
@@ -315,7 +315,7 @@ function sortURL($sort) {
 
 // escape special characters
 function escape_chars($text) {
-   $chr = '<>+-&|!(){}[]^"~*?:/= @\'$.#\\';
+   $chr = '<>+-&|!(){}[]^"~*?:/= @\'$.#\\　';
    return addcslashes($text, $chr);
 }
 


### PR DESCRIPTION
Ideographic space (U+3000) needs to be escaped, as it breaks the calculation of the folder sizes that contain that type of space.
Closes shirosaidev/diskover#77